### PR TITLE
Fix rendering of int64 values on non-MSVC builds

### DIFF
--- a/src/Sim.cpp
+++ b/src/Sim.cpp
@@ -3756,19 +3756,19 @@ void SIM::SaveHighscores() {
                 k1 = k2 = k3 = k4 = k5 = 0;
             }
 
-            str = bprintf("%I64i;", k1);
+            str = bprintf("%" PR_I64i ";", k1);
             OutputFile.Write(reinterpret_cast<const UBYTE *>((LPCTSTR)str), str.GetLength());
 
-            str = bprintf("%I64i;", k2);
+            str = bprintf("%" PR_I64i ";", k2);
             OutputFile.Write(reinterpret_cast<const UBYTE *>((LPCTSTR)str), str.GetLength());
 
-            str = bprintf("%I64i;", k3);
+            str = bprintf("%" PR_I64i ";", k3);
             OutputFile.Write(reinterpret_cast<const UBYTE *>((LPCTSTR)str), str.GetLength());
 
-            str = bprintf("%I64i;", k4);
+            str = bprintf("%" PR_I64i ";", k4);
             OutputFile.Write(reinterpret_cast<const UBYTE *>((LPCTSTR)str), str.GetLength());
 
-            str = bprintf("%I64i\xd\xa", k5);
+            str = bprintf("%" PR_I64i "\\xd\\xa", k5);
             OutputFile.Write(reinterpret_cast<const UBYTE *>((LPCTSTR)str), str.GetLength());
         }
     } catch (TeakLibException &e) {

--- a/src/Statistk.cpp
+++ b/src/Statistk.cpp
@@ -952,7 +952,7 @@ void CStatistik::RepaintTextWindow() {
                         break;
 
                     case TYP_VALUE:
-                        output = bprintf("%I64i", val);
+                        output = bprintf("%" PR_I64i, val);
 
                         if (item.visible) {
                             summe += val;

--- a/src/defines.h
+++ b/src/defines.h
@@ -38,6 +38,7 @@ typedef signed char SBYTE;
 
 #ifdef WIN32
 typedef int32_t SLONG;
+#define PR_I64i "I64i"
 #else
 typedef int32_t SLONG;
 typedef uint32_t ULONG;
@@ -58,6 +59,7 @@ typedef const char *LPCTSTR;
 typedef char *LPTSTR;
 
 typedef long long __int64;
+#define PR_I64i "lli"
 
 typedef struct tagPOINT {
     SLONG x;


### PR DESCRIPTION
Please confirm if this still works fine on other platforms but without that change MacOS M1 build gave me this.
<img width="1003" height="570" alt="image" src="https://github.com/user-attachments/assets/02a0394c-ac76-4f6e-8c4f-b6955916045c" />
